### PR TITLE
examples: Free image_matrix on fmt2rgb888 failure

### DIFF
--- a/examples/single_chip/detection_with_command_line/main/app_facenet.c
+++ b/examples/single_chip/detection_with_command_line/main/app_facenet.c
@@ -72,6 +72,7 @@ void task_process (void *arg)
         if (true != res)
         {
             ESP_LOGE(TAG, "fmt2rgb888 failed, fb: %d", fb->len);
+            dl_matrix3du_free(image_matrix);
             continue;
         }
 

--- a/examples/single_chip/recognition_with_command_line/main/app_facenet.c
+++ b/examples/single_chip/recognition_with_command_line/main/app_facenet.c
@@ -101,6 +101,7 @@ void task_process(void *arg)
         if (true != res)
         {
             ESP_LOGE(TAG, "fmt2rgb888 failed, fb: %d", fb->len);
+            dl_matrix3du_free(image_matrix);
             continue;
         }
 


### PR DESCRIPTION
Signed-off-by: Sachin Parekh <sachin.parekh@espressif.com>