### PR TITLE
camera_web_server: add ESP_EYE camera pin configuration option

### DIFF
--- a/examples/single_chip/camera_web_server/main/Kconfig.projbuild
+++ b/examples/single_chip/camera_web_server/main/Kconfig.projbuild
@@ -45,6 +45,8 @@ choice CAMERA_MODEL
 
 config CAMERA_MODEL_WROVER_KIT
     bool "WROVER-KIT With OV2640 Module"
+config CAMERA_MODEL_ESP_EYE
+    bool "ESP_EYE DevKit"
 config CAMERA_MODEL_M5STACK_PSRAM
     bool "M5Stack Camera With PSRAM"
 config CAMERA_MODEL_AI_THINKER

--- a/examples/single_chip/camera_web_server/main/include/app_camera.h
+++ b/examples/single_chip/camera_web_server/main/include/app_camera.h
@@ -43,6 +43,25 @@
 #define HREF_GPIO_NUM    23
 #define PCLK_GPIO_NUM    22
 
+#elif CONFIG_CAMERA_MODEL_ESP_EYE
+#define PWDN_GPIO_NUM    -1
+#define RESET_GPIO_NUM   -1
+#define XCLK_GPIO_NUM    4
+#define SIOD_GPIO_NUM    18
+#define SIOC_GPIO_NUM    23
+
+#define Y9_GPIO_NUM      36
+#define Y8_GPIO_NUM      37
+#define Y7_GPIO_NUM      38
+#define Y6_GPIO_NUM      39
+#define Y5_GPIO_NUM      35
+#define Y4_GPIO_NUM      14
+#define Y3_GPIO_NUM      13
+#define Y2_GPIO_NUM      34
+#define VSYNC_GPIO_NUM   5
+#define HREF_GPIO_NUM    27
+#define PCLK_GPIO_NUM    25
+
 #elif CONFIG_CAMERA_MODEL_M5STACK_PSRAM
 #define PWDN_GPIO_NUM     -1
 #define RESET_GPIO_NUM    15


### PR DESCRIPTION
The guide docs/en/get-started/ESP-EYE_Getting_Started_Guide.md implies that any of the examples could be built for the ESP-EYE DevKit, but if the camera_web_server example is built with the default configuration, the following errors result:

E (477) camera: Camera probe failed with error 0x20001
E (487) app_camera: Camera init failed with error 0x20001

The problem is that the default camera pin configuration is for the WROVER-KIT but the pinout for the ESP-EYE has changed.  Here I have added  a configuration option for ESP-EYE, but I have left the default selection as WROVER-KIT.