### PR TITLE
Fix UB by avoiding duplicate httpd_resp_send_x

### DIFF
--- a/examples/single_chip/camera_web_server/main/app_httpd.c
+++ b/examples/single_chip/camera_web_server/main/app_httpd.c
@@ -692,8 +692,10 @@ static esp_err_t cmd_handler(httpd_req_t *req)
     char variable[32];
     char value[32];
 
-    if (parse_get(req, &buf) != ESP_OK ||
-        httpd_query_key_value(buf, "var", variable, sizeof(variable)) != ESP_OK ||
+    if (parse_get(req, &buf) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    if (httpd_query_key_value(buf, "var", variable, sizeof(variable)) != ESP_OK ||
         httpd_query_key_value(buf, "val", value, sizeof(value)) != ESP_OK) {
         free(buf);
         httpd_resp_send_404(req);
@@ -901,8 +903,10 @@ static esp_err_t xclk_handler(httpd_req_t *req)
     char *buf = NULL;
     char _xclk[32];
 
-    if (parse_get(req, &buf) != ESP_OK ||
-        httpd_query_key_value(buf, "xclk", _xclk, sizeof(_xclk)) != ESP_OK) {
+    if (parse_get(req, &buf) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    if (httpd_query_key_value(buf, "xclk", _xclk, sizeof(_xclk)) != ESP_OK) {
         free(buf);
         httpd_resp_send_404(req);
         return ESP_FAIL;
@@ -929,8 +933,10 @@ static esp_err_t reg_handler(httpd_req_t *req)
     char _mask[32];
     char _val[32];
 
-    if (parse_get(req, &buf) != ESP_OK ||
-        httpd_query_key_value(buf, "reg", _reg, sizeof(_reg)) != ESP_OK ||
+    if (parse_get(req, &buf) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    if (httpd_query_key_value(buf, "reg", _reg, sizeof(_reg)) != ESP_OK ||
         httpd_query_key_value(buf, "mask", _mask, sizeof(_mask)) != ESP_OK ||
         httpd_query_key_value(buf, "val", _val, sizeof(_val)) != ESP_OK) {
         free(buf);
@@ -960,8 +966,10 @@ static esp_err_t greg_handler(httpd_req_t *req)
     char _reg[32];
     char _mask[32];
 
-    if (parse_get(req, &buf) != ESP_OK ||
-        httpd_query_key_value(buf, "reg", _reg, sizeof(_reg)) != ESP_OK ||
+    if (parse_get(req, &buf) != ESP_OK) {
+        return ESP_FAIL;
+    }
+    if (httpd_query_key_value(buf, "reg", _reg, sizeof(_reg)) != ESP_OK ||
         httpd_query_key_value(buf, "mask", _mask, sizeof(_mask)) != ESP_OK) {
         free(buf);
         httpd_resp_send_404(req);
@@ -998,8 +1006,6 @@ static esp_err_t pll_handler(httpd_req_t *req)
     char *buf = NULL;
 
     if (parse_get(req, &buf) != ESP_OK) {
-        free(buf);
-        httpd_resp_send_404(req);
         return ESP_FAIL;
     }
 
@@ -1029,8 +1035,6 @@ static esp_err_t win_handler(httpd_req_t *req)
     char *buf = NULL;
 
     if (parse_get(req, &buf) != ESP_OK) {
-        free(buf);
-        httpd_resp_send_404(req);
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
parse_get already cleans buf if something went wrong. Therefore the concatenated if conditions containing parse_get needs to be split to avoid UB in some cases which might cause a crash.