### PR TITLE
Fix typo for C++ declaration

### DIFF
--- a/components/esp-sr/acoustic_algorithm/include/esp_ns.h
+++ b/components/esp-sr/acoustic_algorithm/include/esp_ns.h
@@ -64,7 +64,7 @@ void ns_process(ns_handle_t inst, int16_t *indata, int16_t *outdata);
 void ns_destroy(ns_handle_t inst);
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif //_ESP_NS_H_


### PR DESCRIPTION
accidentially extern "C" is opened twice.