### PR TITLE
increase stack size of who_camera task (AIV-596)

### DIFF
--- a/components/modules/camera/who_camera.c
+++ b/components/modules/camera/who_camera.c
@@ -83,5 +83,5 @@ void register_camera(const pixformat_t pixel_fromat,
     }
 
     xQueueFrameO = frame_o;
-    xTaskCreatePinnedToCore(task_process_handler, TAG, 2 * 1024, NULL, 5, NULL, 1);
+    xTaskCreatePinnedToCore(task_process_handler, TAG, 3 * 1024, NULL, 5, NULL, 1);
 }


### PR DESCRIPTION
Inside the esp-who examples including human_face_detect/web, When the esp32-camera driver failed to return a frame, the who_camera task would experience a stack overflow and crash entirely rebooting the ESP32.

Previous commit 91b61dc increased the stack size from 1 * 1024 to 2 *1024. 

This works as long as there is no error condition.  I further increased the stack size of the who_camera task to 3 * 1024 and it is able to handle intermittent errors in the esp32-camera driver without crashing the task or rebooting the ESP32.

combined with: 
https://github.com/espressif/esp32-camera/pull/523

will fix these issues:
https://github.com/espressif/esp32-camera/issues/488
https://github.com/espressif/esp-who/issues/249